### PR TITLE
Update modulefederation.config.js

### DIFF
--- a/modulefederation.config.js
+++ b/modulefederation.config.js
@@ -4,12 +4,14 @@ const makeShared = (pkgs, eager) => {
         packageObj => {
             if (typeof packageObj === 'string') {
                 result[packageObj] = {
+                    version: '*',
                     requiredVersion: '*',
                     singleton: true,
                     eager,
                 };
             } else {
                 result[packageObj.name] = {
+                    version: packageObj.version || '*',
                     requiredVersion: packageObj.requiredVersion || '*',
                     singleton: packageObj.singleton !== undefined ? packageObj.singleton : true,
                     eager: packageObj.eager !== undefined ? packageObj.eager : eager,


### PR DESCRIPTION
Beim build run für die Erstellung von vis-2 Widgets bekomme ich folgende Meldung:

```
D:\dev-workspace\ioBroker.vis-2-widgets-radar-trap> npm run build

iobroker.vis-2-widgets-radar-trap@2.0.0 build
gulp

[10:35:48] Using gulpfile D:\dev-workspace\ioBroker.vis-2-widgets-radar-trap\gulpfile.js
[10:35:48] Starting 'default'...
[10:35:48] Starting 'widget-build'...
[10:35:48] Starting 'widget-0-clean'...
[10:35:48] Finished 'widget-0-clean' after 72 ms
[10:35:48] Starting 'widget-1-npm'...
"npm install -f in D:/dev-workspace/ioBroker.vis-2-widgets-radar-trap/src-widgets/
npm warn using --force Recommended protections disabled.

up to date, audited 3442 packages in 20s

458 packages are looking for funding
  run `npm fund` for details        

161 vulnerabilities (1 low, 97 moderate, 52 high, 11 critical)   

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
"npm install -f in D:/dev-workspace/ioBroker.vis-2-widgets-radar-trap/src-widgets/ finished.
[10:36:09] Finished 'widget-1-npm' after 21 s
[10:36:09] Starting 'widget-2-compile'...
D:\dev-workspace\ioBroker.vis-2-widgets-radar-trap/src-widgets/

Creating an optimized production build...

Compiled with warnings.


No version specified and unable to automatically determine one. No version in description file (usually package.json). Add version to description file D:\dev-workspace\ioBroker.vis-2-widgets-radar-trap\src-widgets\node_modules\@iobroker\vis-2-widgets-react-dev\node_modules\@mui\material\styles\package.json, or manually specify version in shared config.

```

Durch die Einführung des sharing hints  "version" in  modulefederation.config.js verschwindet das Problem und die test-and-release.yml läuft sauber durch, ohne mit der Meldung während des workflow runs abzubrechen.